### PR TITLE
Feat: 어드민 장소 리스트 조회 시 유저 등록 신청, 관리자 등록 탭 분리

### DIFF
--- a/src/main/java/com/jigumulmi/admin/AdminService.java
+++ b/src/main/java/com/jigumulmi/admin/AdminService.java
@@ -89,7 +89,7 @@ public class AdminService {
             Sort.by(requestDto.getDirection(), "id"));
 
         Page<PlaceDto> placePage = customAdminRepository.getPlaceList(pageable,
-            requestDto.getPlaceName());
+            requestDto);
 
         return AdminPlaceListResponseDto.builder()
             .data(placePage.getContent())

--- a/src/main/java/com/jigumulmi/admin/dto/request/AdminGetPlaceListRequestDto.java
+++ b/src/main/java/com/jigumulmi/admin/dto/request/AdminGetPlaceListRequestDto.java
@@ -23,7 +23,10 @@ public class AdminGetPlaceListRequestDto {
     @Parameter(description = "id 기준 오름차순/내림차순")
     @Schema(defaultValue = "ASC")
     private Direction direction = Direction.ASC;
-    
+
     @Parameter(description = "장소 검색어, 검색어로 시작하는 장소 조회")
     private String placeName;
+
+    @Parameter(description = "유저 등록 신청 -> false, 관리자 등록 -> true")
+    private Boolean isFromAdmin;
 }

--- a/src/main/java/com/jigumulmi/admin/dto/response/AdminMemberListResponseDto.java
+++ b/src/main/java/com/jigumulmi/admin/dto/response/AdminMemberListResponseDto.java
@@ -34,6 +34,6 @@ public class AdminMemberListResponseDto {
 
     }
 
-    private List<MemberDto> data;
     private PageDto page;
+    private List<MemberDto> data;
 }

--- a/src/main/java/com/jigumulmi/admin/dto/response/AdminPlaceDetailResponseDto.java
+++ b/src/main/java/com/jigumulmi/admin/dto/response/AdminPlaceDetailResponseDto.java
@@ -22,7 +22,6 @@ public class AdminPlaceDetailResponseDto extends PlaceDetailResponseDto {
     private Boolean isApproved;
     private String kakaoPlaceId;
     private String googlePlaceId;
-    private Boolean isFromAdmin;
 
     public static AdminPlaceDetailResponseDto from(Place place) {
         List<SubwayStationPlace> subwayStationPlaceList = place.getSubwayStationPlaceList();
@@ -75,7 +74,6 @@ public class AdminPlaceDetailResponseDto extends PlaceDetailResponseDto {
             .menuList(menuList)
             .kakaoPlaceId(place.getKakaoPlaceId())
             .googlePlaceId(place.getGooglePlaceId())
-            .isFromAdmin(place.getIsFromAdmin())
             .build();
     }
 }

--- a/src/main/java/com/jigumulmi/admin/dto/response/AdminPlaceListResponseDto.java
+++ b/src/main/java/com/jigumulmi/admin/dto/response/AdminPlaceListResponseDto.java
@@ -18,10 +18,9 @@ public class AdminPlaceListResponseDto {
 
         private String category;
         private Boolean isApproved;
-        private Boolean isFromAdmin;
         private String googlePlaceId;
     }
 
-    private List<PlaceDto> data;
     private PageDto page;
+    private List<PlaceDto> data;
 }

--- a/src/main/java/com/jigumulmi/admin/repository/CustomAdminRepository.java
+++ b/src/main/java/com/jigumulmi/admin/repository/CustomAdminRepository.java
@@ -1,6 +1,7 @@
 package com.jigumulmi.admin.repository;
 
 
+import com.jigumulmi.admin.dto.request.AdminGetPlaceListRequestDto;
 import com.jigumulmi.admin.dto.response.AdminPlaceListResponseDto.PlaceDto;
 import com.jigumulmi.place.domain.Place;
 import com.jigumulmi.place.dto.response.SubwayStationResponseDto;
@@ -29,7 +30,7 @@ public class CustomAdminRepository {
 
     private final JPAQueryFactory queryFactory;
 
-    public Page<PlaceDto> getPlaceList(Pageable pageable, String placeName) {
+    public Page<PlaceDto> getPlaceList(Pageable pageable, AdminGetPlaceListRequestDto requestDto) {
         List<PlaceDto> content = queryFactory
             .select(
                 Projections.fields(PlaceDto.class,
@@ -42,7 +43,6 @@ public class CustomAdminRepository {
                     ).as("subwayStation"),
                     place.category,
                     place.isApproved,
-                    place.isFromAdmin,
                     place.googlePlaceId
                 )
             )
@@ -50,7 +50,8 @@ public class CustomAdminRepository {
             .leftJoin(place.subwayStationPlaceList, subwayStationPlace)
             .on(place.id.eq(subwayStationPlace.place.id).and(subwayStationPlace.isMain.eq(true)))
             .leftJoin(subwayStationPlace.subwayStation, subwayStation)
-            .where(placeCondition(placeName))
+            .where(place.isFromAdmin.eq(requestDto.getIsFromAdmin())
+                .and(placeCondition(requestDto.getPlaceName())))
             .orderBy(getOrderSpecifier(pageable.getSort(), Expressions.path(Place.class, "place")))
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())


### PR DESCRIPTION
<!-- 
PR 제목에 쓰는 prefix는 다음과 같습니다.
Feat : 새로운 기능에 대한 작업
BugFix : 버그 수정에 대한 작업
Refactor : 코드 리팩토링에 대한 작업
Build : 빌드 관련 파일 수정에 대한 작업
Style : 코드 스타일 혹은 포맷 등에 관한 작업
CI : CI 관련 설정 수정에 대한 작업
Docs : 문서 수정에 대한 작업
Test : 테스트 코드 관련 작업
Chore : 그 외 자잘한 수정에 대한 작업(파일 이름 변경, 주석 수정 등)
-->

## 체크사항

<!-- 체크하려면 괄호 안에 "x"를 입력하세요.  -->
PR이 다음 사항을 만족하는지 확인해주세요.

- [x] 커밋 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정

## 작업사항

<!-- 무엇을 왜 했는지 -->
- 어드민 페이지에서 유저가 등록 신청한 장소를 구분하기 위해 장소 리스트 조회 api에 isFromAdmin 파라미터 추가
- 어드민 장소 상세, 리스트 조회 시 응답에 isFromAdmin 제거

## 참고사항
- 