### PR TITLE
BugFix: 카카오장소id 빈 스트링 중복 처리

### DIFF
--- a/src/main/java/com/jigumulmi/admin/dto/request/AdminCreatePlaceRequestDto.java
+++ b/src/main/java/com/jigumulmi/admin/dto/request/AdminCreatePlaceRequestDto.java
@@ -4,6 +4,7 @@ import com.jigumulmi.place.dto.response.PlaceDetailResponseDto;
 import com.jigumulmi.place.dto.response.PlaceResponseDto.PositionDto;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -34,6 +35,10 @@ public class AdminCreatePlaceRequestDto {
     private String additionalInfo;
     private String registrantComment;
     private Boolean isApproved = false;
-    private List<Long> subwayStationIdList;
-    private String kakaoPlaceId;
+    private List<Long> subwayStationIdList = new ArrayList<>();
+    private String kakaoPlaceId = null;
+
+    private void setKakaoPlaceId(String kakaoPlaceId) {
+        this.kakaoPlaceId = (Objects.equals(kakaoPlaceId, "")) ? null : kakaoPlaceId;
+    }
 }


### PR DESCRIPTION
<!-- 
PR 제목에 쓰는 prefix는 다음과 같습니다.
Feat : 새로운 기능에 대한 작업
BugFix : 버그 수정에 대한 작업
Refactor : 코드 리팩토링에 대한 작업
Build : 빌드 관련 파일 수정에 대한 작업
Style : 코드 스타일 혹은 포맷 등에 관한 작업
CI : CI 관련 설정 수정에 대한 작업
Docs : 문서 수정에 대한 작업
Test : 테스트 코드 관련 작업
Chore : 그 외 자잘한 수정에 대한 작업(파일 이름 변경, 주석 수정 등)
-->

## 체크사항

<!-- 체크하려면 괄호 안에 "x"를 입력하세요.  -->
PR이 다음 사항을 만족하는지 확인해주세요.

- [x] 커밋 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정

## 작업사항

<!-- 무엇을 왜 했는지 -->
- 어드민 장소 생성 시 kakaoPlaceId가 빈스트링으로 넘어오고 있어 그 경우 null로 변환하여 DB 저장
- place 테이블에 kakaoPlaceId에 해당하는 컬럼에 대해 unique key가 있어 중복 처리되기 때문

## 참고사항
- 