### PR TITLE
Refactor: mysql enum -> varchar

### DIFF
--- a/src/main/java/com/jigumulmi/place/domain/Place.java
+++ b/src/main/java/com/jigumulmi/place/domain/Place.java
@@ -46,12 +46,12 @@ public class Place extends Timestamped {
     private String name;
 
     @Comment("광역시도")
-    @Column(length = 40)
+    @Column(columnDefinition = "varchar(40)")
     @Enumerated(EnumType.STRING)
     private Region region;
 
     @Comment("시군구")
-    @Column(length = 40)
+    @Column(columnDefinition = "varchar(40)")
     @Enumerated(EnumType.STRING)
     private District district;
 

--- a/src/main/java/com/jigumulmi/place/domain/PlaceCategoryMapping.java
+++ b/src/main/java/com/jigumulmi/place/domain/PlaceCategoryMapping.java
@@ -1,9 +1,9 @@
-
 package com.jigumulmi.place.domain;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.jigumulmi.place.vo.PlaceCategory;
 import com.jigumulmi.place.vo.PlaceCategoryGroup;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -40,9 +40,11 @@ public class PlaceCategoryMapping {
     private Place place;
 
     @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "varchar(30)")
     private PlaceCategory category;
 
     @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "varchar(30)")
     private PlaceCategoryGroup categoryGroup;
 
     @Builder


### PR DESCRIPTION
<!-- 
PR 제목에 쓰는 prefix는 다음과 같습니다.
Feat : 새로운 기능에 대한 작업
BugFix : 버그 수정에 대한 작업
Refactor : 코드 리팩토링에 대한 작업
Build : 빌드 관련 파일 수정에 대한 작업
Style : 코드 스타일 혹은 포맷 등에 관한 작업
CI : CI 관련 설정 수정에 대한 작업
Docs : 문서 수정에 대한 작업
Test : 테스트 코드 관련 작업
Chore : 그 외 자잘한 수정에 대한 작업(파일 이름 변경, 주석 수정 등)
-->

## 작업사항
<!-- 무엇을 왜 했는지 -->
- 애플리케이션 단에서 enum으로 관리하기 때문에 MySQL의 컬럼 타입을 enum으로 할 필요없고, 복잡성이 증가하여 varchar로 수정

## 참고사항
- 

## 관련 이슈
- closed #