### PR TITLE
BugFix: prometheus 도커 컨테이너에서 호스트 연결

### DIFF
--- a/monitor/docker-compose.yml
+++ b/monitor/docker-compose.yml
@@ -31,6 +31,8 @@ services:
     container_name: prometheus
     ports:
       - "9090:9090"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     command:
       - --config.file=/etc/prometheus/prometheus.yml
       - --storage.tsdb.retention.size=2GB


### PR DESCRIPTION
<!-- 
PR 제목에 쓰는 prefix는 다음과 같습니다.
Feat : 새로운 기능에 대한 작업
BugFix : 버그 수정에 대한 작업
Refactor : 코드 리팩토링에 대한 작업
Build : 빌드 관련 파일 수정에 대한 작업
Style : 코드 스타일 혹은 포맷 등에 관한 작업
CI : CI 관련 설정 수정에 대한 작업
Docs : 문서 수정에 대한 작업
Test : 테스트 코드 관련 작업
Chore : 그 외 자잘한 수정에 대한 작업(파일 이름 변경, 주석 수정 등)
-->

## 작업사항
<!-- 무엇을 왜 했는지 -->
- ubuntu에서 `host.docker.internal`을 인식할 수 있도록 `docker-compose.yml` 수정하여 prometheus가 메트릭 수집을 하지 못하는 버그 픽스

## 참고사항
- [아티클 참고](https://medium.com/@TimvanBaarsen/how-to-connect-to-the-docker-host-from-inside-a-docker-container-112b4c71bc66)

## 관련 이슈
- closed #