### PR TITLE
Feat: 배너 목록 조회 응답에 내부 이미지 데이터 추가 & 장소 목록 조회 응답에 좌표 데이터 추가

### DIFF
--- a/src/main/java/com/jigumulmi/banner/dto/response/BannerPlaceListResponseDto.java
+++ b/src/main/java/com/jigumulmi/banner/dto/response/BannerPlaceListResponseDto.java
@@ -4,6 +4,7 @@ import com.jigumulmi.banner.dto.response.BannerPlaceListResponseDto.BannerPlaceD
 import com.jigumulmi.common.PagedResponseDto;
 import com.jigumulmi.place.domain.Place;
 import com.jigumulmi.place.dto.ImageDto;
+import com.jigumulmi.place.dto.PositionDto;
 import com.jigumulmi.place.dto.response.PlaceCategoryDto;
 import com.jigumulmi.place.dto.response.SurroundingDateBusinessHour;
 import com.jigumulmi.place.vo.CurrentOpeningStatus;
@@ -27,6 +28,7 @@ public class BannerPlaceListResponseDto extends PagedResponseDto<BannerPlaceDto>
         private String name;
         private Region region;
         private District district;
+        private PositionDto position;
         private List<PlaceCategoryDto> categoryList;
         private List<ImageDto> imageList;
         private CurrentOpeningStatus currentOpeningStatus;
@@ -37,6 +39,12 @@ public class BannerPlaceListResponseDto extends PagedResponseDto<BannerPlaceDto>
                 .name(place.getName())
                 .region(place.getRegion())
                 .district(place.getDistrict())
+                .position(
+                    PositionDto.builder()
+                        .longitude(place.getLongitude())
+                        .latitude(place.getLatitude())
+                        .build()
+                )
                 .categoryList(place.getCategoryMappingList().stream()
                     .map(PlaceCategoryDto::fromPlaceCategoryMapping).toList())
                 .imageList(place.getPlaceImageList().stream()

--- a/src/main/java/com/jigumulmi/banner/dto/response/BannerResponseDto.java
+++ b/src/main/java/com/jigumulmi/banner/dto/response/BannerResponseDto.java
@@ -11,12 +11,14 @@ public class BannerResponseDto {
     private Long id;
     private String title;
     private String outerImageS3Key;
+    private String innerImageS3Key;
 
     public static BannerResponseDto from(Banner banner) {
         return BannerResponseDto.builder()
             .id(banner.getId())
             .title(banner.getTitle())
             .outerImageS3Key(banner.getOuterImageS3Key())
+            .innerImageS3Key(banner.getInnerImageS3Key())
             .build();
     }
 }

--- a/src/main/java/com/jigumulmi/place/dto/response/PlaceBasicResponseDto.java
+++ b/src/main/java/com/jigumulmi/place/dto/response/PlaceBasicResponseDto.java
@@ -2,7 +2,6 @@ package com.jigumulmi.place.dto.response;
 
 import com.jigumulmi.admin.place.dto.WeeklyBusinessHourDto;
 import com.jigumulmi.place.dto.ImageDto;
-import com.jigumulmi.place.dto.PositionDto;
 import com.jigumulmi.place.dto.TimeDto;
 import com.jigumulmi.place.vo.CurrentOpeningStatus;
 import com.jigumulmi.place.vo.NextOpeningStatus;
@@ -34,7 +33,6 @@ public class PlaceBasicResponseDto {
             private LocalTime at;
         }
 
-
         private CurrentOpeningStatus currentOpeningStatus;
         @Schema(description = "현재 상태가 휴무 혹은 영업 종료인 경우 null")
         private NextOpeningInfo nextOpeningInfo;
@@ -44,7 +42,6 @@ public class PlaceBasicResponseDto {
 
     private Long id;
     private String name;
-    private PositionDto position;
     private String address;
     private String contact;
     private String additionalInfo;

--- a/src/main/java/com/jigumulmi/place/repository/CustomPlaceRepository.java
+++ b/src/main/java/com/jigumulmi/place/repository/CustomPlaceRepository.java
@@ -8,7 +8,6 @@ import static com.jigumulmi.place.domain.QPlace.place;
 import static com.jigumulmi.place.domain.QPlaceCategoryMapping.placeCategoryMapping;
 import static com.jigumulmi.place.domain.QPlaceLike.placeLike;
 import static com.jigumulmi.place.domain.QReview.review;
-import static com.jigumulmi.place.domain.QReviewImage.reviewImage;
 import static com.jigumulmi.place.domain.QReviewReply.reviewReply;
 import static com.jigumulmi.place.domain.QSubwayStation.subwayStation;
 import static com.jigumulmi.place.domain.QSubwayStationLine.subwayStationLine;
@@ -27,7 +26,6 @@ import com.jigumulmi.member.domain.Member;
 import com.jigumulmi.member.dto.response.MemberDetailResponseDto;
 import com.jigumulmi.place.domain.Review;
 import com.jigumulmi.place.dto.BusinessHour;
-import com.jigumulmi.place.dto.PositionDto;
 import com.jigumulmi.place.dto.response.PlaceBasicResponseDto;
 import com.jigumulmi.place.dto.response.ReviewReplyResponseDto;
 import com.jigumulmi.place.dto.response.SubwayStationResponseDto;
@@ -107,10 +105,6 @@ public class CustomPlaceRepository {
                     Projections.fields(PlaceBasicResponseDto.class,
                         place.id,
                         place.name,
-                        Projections.fields(PositionDto.class,
-                            place.latitude,
-                            place.longitude
-                        ).as("position"),
                         place.address,
                         place.contact,
                         place.additionalInfo,


### PR DESCRIPTION
<!-- 
PR 제목에 쓰는 prefix는 다음과 같습니다.
Feat : 새로운 기능에 대한 작업
BugFix : 버그 수정에 대한 작업
Refactor : 코드 리팩토링에 대한 작업
Build : 빌드 관련 파일 수정에 대한 작업
Style : 코드 스타일 혹은 포맷 등에 관한 작업
CI : CI 관련 설정 수정에 대한 작업
Docs : 문서 수정에 대한 작업
Test : 테스트 코드 관련 작업
Chore : 그 외 자잘한 수정에 대한 작업(파일 이름 변경, 주석 수정 등)
-->

## 작업사항
<!-- 무엇을 왜 했는지 -->
- 누락된 기능 추가
- 배너 클릭 시 필요한 `innerImageS3Key`를 배너 목록 조회 응답에 추가
- 장소 목록 페이지에서 지도에 장소들을 표현하기 위한 좌표 데이터추가
- 장소 상세 조회 시 좌표 데이터 제거 

## 참고사항
- 

## 관련 이슈
- closed #190 