### PR TITLE
BugFix: 메뉴 수정 시 이미지 확장자 데이터 제거

### DIFF
--- a/src/main/java/com/jigumulmi/common/FileUtils.java
+++ b/src/main/java/com/jigumulmi/common/FileUtils.java
@@ -1,10 +1,28 @@
 package com.jigumulmi.common;
 
 import java.util.UUID;
+import org.apache.commons.lang3.StringUtils;
 
 public class FileUtils {
 
     public static String generateUniqueFilename() {
         return UUID.randomUUID().toString();
+    }
+
+    /**
+     * @param filename 경로가 포함되지 않은 파일 이름
+     * @return 확장자가 제거된 파일 이름
+     */
+    public static String getFilenameWithoutExtension(String filename) {
+        return StringUtils.substringBeforeLast(filename, ".");
+    }
+
+    /**
+     * 
+     * @param absolutePath 파일 이름이 포함된 전체 경로
+     * @return 경로가 제거된 파일 이름
+     */
+    public static String getFilenameFromAbsolutePath(String absolutePath) {
+        return StringUtils.substringAfterLast(absolutePath, "/");
     }
 }

--- a/src/main/java/com/jigumulmi/common/FileUtils.java
+++ b/src/main/java/com/jigumulmi/common/FileUtils.java
@@ -19,10 +19,10 @@ public class FileUtils {
 
     /**
      * 
-     * @param absolutePath 파일 이름이 포함된 전체 경로
+     * @param path 파일 이름이 포함된 전체 경로
      * @return 경로가 제거된 파일 이름
      */
-    public static String getFilenameFromAbsolutePath(String absolutePath) {
-        return StringUtils.substringAfterLast(absolutePath, "/");
+    public static String getFilenameFromPath(String path) {
+        return StringUtils.substringAfterLast(path, "/");
     }
 }

--- a/src/main/java/com/jigumulmi/place/dto/MenuDto.java
+++ b/src/main/java/com/jigumulmi/place/dto/MenuDto.java
@@ -3,6 +3,7 @@ package com.jigumulmi.place.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.jigumulmi.aws.S3Manager;
+import com.jigumulmi.common.FileUtils;
 import com.jigumulmi.place.domain.Menu;
 import com.jigumulmi.place.domain.Place;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -25,18 +26,15 @@ public class MenuDto {
 
     private String description;
 
-    @Schema(description = "확장자 포함한 파일 이름")
+    @Schema(description = "확장자 제외한 파일 이름")
     private String fullFilename;
 
     @JsonProperty(access = Access.READ_ONLY)
     private String imageS3Key;
 
     public static MenuDto from(Menu menu) {
-        String fullFilename = null;
         String imageS3Key = menu.getImageS3Key();
-        if (imageS3Key != null) {
-            fullFilename = imageS3Key.substring(imageS3Key.lastIndexOf("/") + 1);
-        }
+        String fullFilename = FileUtils.getFilenameFromAbsolutePath(imageS3Key);
 
         return MenuDto.builder()
             .name(menu.getName())
@@ -51,8 +49,10 @@ public class MenuDto {
     public static Menu toMenu(MenuDto menuDto, Place place) {
         String imageS3Key = null;
         if (menuDto.getFullFilename() != null) {
+            String filenameWithoutExtension = FileUtils.getFilenameWithoutExtension(
+                menuDto.getFullFilename());
             imageS3Key =
-                S3Manager.MENU_IMAGE_S3_PREFIX + place.getId() + "/" + menuDto.getFullFilename();
+                S3Manager.MENU_IMAGE_S3_PREFIX + place.getId() + "/" + filenameWithoutExtension;
         }
 
         return Menu.builder()

--- a/src/main/java/com/jigumulmi/place/dto/MenuDto.java
+++ b/src/main/java/com/jigumulmi/place/dto/MenuDto.java
@@ -26,31 +26,31 @@ public class MenuDto {
 
     private String description;
 
-    @Schema(description = "확장자 제외한 파일 이름")
-    private String fullFilename;
+    @Schema(description = "확장자 제외한 메뉴 이미지 파일 이름")
+    private String imageFilename;
 
     @JsonProperty(access = Access.READ_ONLY)
     private String imageS3Key;
 
     public static MenuDto from(Menu menu) {
         String imageS3Key = menu.getImageS3Key();
-        String fullFilename = FileUtils.getFilenameFromAbsolutePath(imageS3Key);
+        String imageFilename = FileUtils.getFilenameFromPath(imageS3Key);
 
         return MenuDto.builder()
             .name(menu.getName())
             .isMain(menu.getIsMain())
             .price(menu.getPrice())
             .description(menu.getDescription())
-            .fullFilename(fullFilename)
+            .imageFilename(imageFilename)
             .imageS3Key(imageS3Key)
             .build();
     }
 
     public static Menu toMenu(MenuDto menuDto, Place place) {
         String imageS3Key = null;
-        if (menuDto.getFullFilename() != null) {
+        if (menuDto.getImageFilename() != null) {
             String filenameWithoutExtension = FileUtils.getFilenameWithoutExtension(
-                menuDto.getFullFilename());
+                menuDto.getImageFilename());
             imageS3Key =
                 S3Manager.MENU_IMAGE_S3_PREFIX + place.getId() + "/" + filenameWithoutExtension;
         }

--- a/src/test/java/com/jigumulmi/admin/place/AdminPlaceServiceTest.java
+++ b/src/test/java/com/jigumulmi/admin/place/AdminPlaceServiceTest.java
@@ -1,0 +1,85 @@
+package com.jigumulmi.admin.place;
+
+import com.jigumulmi.place.domain.Menu;
+import com.jigumulmi.place.domain.Place;
+import com.jigumulmi.place.dto.MenuDto;
+import com.jigumulmi.place.repository.MenuRepository;
+import com.jigumulmi.place.repository.PlaceRepository;
+import java.util.List;
+import java.util.stream.Stream;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@Transactional
+class AdminPlaceServiceTest {
+
+    @Autowired
+    private AdminPlaceService adminPlaceService;
+
+    @Autowired
+    private MenuRepository menuRepository;
+    @Autowired
+    private PlaceRepository placeRepository;
+
+    private static Stream<Arguments> getMenuImageFilename() {
+        return Stream.of(
+            Arguments.of((String) null),
+            Arguments.of("image"),
+            Arguments.of("image.png"),
+            Arguments.of(""),
+            Arguments.of(".png")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("getMenuImageFilename")
+    @DisplayName("메뉴 수정 - 파일 확장자 제거 테스트")
+    public void testUpdateMenu(String imageFilename) {
+        // given
+        MenuDto menuDto = MenuDto.builder()
+            .imageFilename(imageFilename)
+            .build();
+
+        Place place = Place.builder().build();
+        placeRepository.save(place);
+
+        // when
+        adminPlaceService.updateMenu(place.getId(), List.of(menuDto));
+
+        // then
+        Menu menu = menuRepository.findAllByPlaceId(place.getId()).getFirst();
+        String imageS3Key = menu.getImageS3Key();
+        boolean hasExtension = StringUtils.contains(imageS3Key, ".")
+            && StringUtils.lastIndexOf(imageS3Key, ".") > 0;
+        Assertions.assertFalse(hasExtension);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getMenuImageFilename")
+    @DisplayName("메뉴 목록 조회")
+    public void testGetMenu(String imageFilename) {
+        // given
+        Place place = Place.builder().build();
+        placeRepository.save(place);
+
+        Menu menu = Menu.builder()
+            .place(place)
+            .imageS3Key("prefix/" + imageFilename)
+            .build();
+        menuRepository.save(menu);
+
+        // when
+
+        // then
+        Assertions.assertDoesNotThrow(() -> adminPlaceService.getMenu(place.getId()));
+
+    }
+}


### PR DESCRIPTION
<!-- 
PR 제목에 쓰는 prefix는 다음과 같습니다.
Feat : 새로운 기능에 대한 작업
BugFix : 버그 수정에 대한 작업
Refactor : 코드 리팩토링에 대한 작업
Build : 빌드 관련 파일 수정에 대한 작업
Style : 코드 스타일 혹은 포맷 등에 관한 작업
CI : CI 관련 설정 수정에 대한 작업
Docs : 문서 수정에 대한 작업
Test : 테스트 코드 관련 작업
Chore : 그 외 자잘한 수정에 대한 작업(파일 이름 변경, 주석 수정 등)
-->

## 작업사항
<!-- 무엇을 왜 했는지 -->
- presignedURL을 사용해 S3에 파일 저장 시 확장자가 없이 저장되기 때문에, 백엔드로 넘어오는 파일 이름에도 확장자 데이터가 없어야 일관된다

## 참고사항
- 

## 관련 이슈
- closed #