### PR TITLE
Feat: 승인된 장소 수정, 삭제 시 데이터 검증 로직 추가

### DIFF
--- a/src/main/java/com/jigumulmi/admin/place/AdminPlaceController.java
+++ b/src/main/java/com/jigumulmi/admin/place/AdminPlaceController.java
@@ -72,7 +72,12 @@ public class AdminPlaceController {
     }
 
     @Operation(summary = "장소 기본 정보 수정", description = "덮어쓰는 로직이므로 수정되지 않은 기존 데이터도 필요")
-    @ApiResponse(responseCode = "201")
+    @ApiResponses(
+        {
+            @ApiResponse(responseCode = "201"),
+            @ApiResponse(responseCode = "400", description = "승인된 장소 수정 시 데이터 누락")
+        }
+    )
     @PutMapping("/{placeId}/basic")
     public ResponseEntity<?> updatePlaceBasic(@PathVariable Long placeId,
         @RequestBody AdminCreatePlaceRequestDto requestDto) {
@@ -89,7 +94,12 @@ public class AdminPlaceController {
     }
 
     @Operation(summary = "장소 이미지 수정", description = "덮어쓰는 로직이므로 수정되지 않은 기존 데이터도 필요")
-    @ApiResponse(responseCode = "201")
+    @ApiResponses(
+        {
+            @ApiResponse(responseCode = "201"),
+            @ApiResponse(responseCode = "400", description = "승인된 장소 수정 시 데이터 누락")
+        }
+    )
     @PutMapping("/{placeId}/image")
     public ResponseEntity<?> updatePlaceImage(@PathVariable Long placeId,
         @RequestBody List<ImageDto> requestDto) {
@@ -105,7 +115,12 @@ public class AdminPlaceController {
     }
 
     @Operation(summary = "장소 메뉴 수정", description = "덮어쓰는 로직이므로 수정되지 않은 기존 데이터도 필요")
-    @ApiResponse(responseCode = "201")
+    @ApiResponses(
+        {
+            @ApiResponse(responseCode = "201"),
+            @ApiResponse(responseCode = "400", description = "승인된 장소 수정 시 데이터 누락")
+        }
+    )
     @PutMapping("/{placeId}/menu")
     public ResponseEntity<?> updateMenu(@PathVariable Long placeId,
         @RequestBody List<MenuDto> requestDto) {

--- a/src/main/java/com/jigumulmi/admin/place/AdminPlaceController.java
+++ b/src/main/java/com/jigumulmi/admin/place/AdminPlaceController.java
@@ -182,8 +182,8 @@ public class AdminPlaceController {
     @PostMapping("/{placeId}/approval")
     public ResponseEntity<?> togglePlaceApprove(@PathVariable Long placeId,
         @Valid @RequestBody TogglePlaceApproveRequestDto requestDto) {
-        adminPlaceService.togglePlaceApprove(placeId, requestDto.getIsApproved());
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+        adminPlaceService.togglePlaceApprove(placeId, requestDto.getApprove());
+        return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "장소 삭제")

--- a/src/main/java/com/jigumulmi/admin/place/AdminPlaceController.java
+++ b/src/main/java/com/jigumulmi/admin/place/AdminPlaceController.java
@@ -175,7 +175,7 @@ public class AdminPlaceController {
     @Operation(summary = "장소 승인/미승인")
     @ApiResponses(
         {
-            @ApiResponse(responseCode = "201", description = "장소 승인 여부 업데이트 성공"),
+            @ApiResponse(responseCode = "204", description = "장소 승인 여부 업데이트 성공"),
             @ApiResponse(responseCode = "400", description = "장소 승인 검증 실패")
         }
     )
@@ -183,7 +183,7 @@ public class AdminPlaceController {
     public ResponseEntity<?> togglePlaceApprove(@PathVariable Long placeId,
         @Valid @RequestBody TogglePlaceApproveRequestDto requestDto) {
         adminPlaceService.togglePlaceApprove(placeId, requestDto.getIsApproved());
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
     @Operation(summary = "장소 삭제")

--- a/src/main/java/com/jigumulmi/admin/place/AdminPlaceManager.java
+++ b/src/main/java/com/jigumulmi/admin/place/AdminPlaceManager.java
@@ -426,4 +426,13 @@ public class AdminPlaceManager {
             .url(url)
             .build();
     }
+
+    public void validatePlaceModification(Long placeId) {
+        Place place = placeRepository.findById(placeId)
+            .orElseThrow(() -> new CustomException(CommonErrorCode.RESOURCE_NOT_FOUND));
+
+        if (place.getIsApproved()) {
+            throw new CustomException(AdminErrorCode.INVALID_PLACE_MODIFICATION);
+        }
+    }
 }

--- a/src/main/java/com/jigumulmi/admin/place/AdminPlaceManager.java
+++ b/src/main/java/com/jigumulmi/admin/place/AdminPlaceManager.java
@@ -331,8 +331,8 @@ public class AdminPlaceManager {
     }
 
     @Transactional(readOnly = true)
-    public void validatePlaceApprovalIfNeeded(Long placeId, boolean isApproved) {
-        if (!isApproved) {
+    public void validatePlaceApprovalIfNeeded(Long placeId, boolean approve) {
+        if (!approve) {
             return;
         }
 
@@ -379,11 +379,11 @@ public class AdminPlaceManager {
     }
 
     @Transactional
-    public void togglePlaceApprove(Long placeId, boolean isApproved) {
+    public void togglePlaceApprove(Long placeId, boolean approve) {
         Place place = placeRepository.findById(placeId)
             .orElseThrow(() -> new CustomException((CommonErrorCode.RESOURCE_NOT_FOUND)));
 
-        place.adminUpdateIsApproved(isApproved);
+        place.adminUpdateIsApproved(approve);
     }
 
     public void deletePlace(Long placeId) {

--- a/src/main/java/com/jigumulmi/admin/place/AdminPlaceService.java
+++ b/src/main/java/com/jigumulmi/admin/place/AdminPlaceService.java
@@ -104,9 +104,9 @@ public class AdminPlaceService {
     }
 
     @Transactional
-    public void togglePlaceApprove(Long placeId, boolean isApproved) {
-        adminPlaceManager.validatePlaceApprovalIfNeeded(placeId, isApproved);
-        adminPlaceManager.togglePlaceApprove(placeId, isApproved);
+    public void togglePlaceApprove(Long placeId, boolean approve) {
+        adminPlaceManager.validatePlaceApprovalIfNeeded(placeId, approve);
+        adminPlaceManager.togglePlaceApprove(placeId, approve);
     }
 
     public void deletePlace(Long placeId) {

--- a/src/main/java/com/jigumulmi/admin/place/AdminPlaceService.java
+++ b/src/main/java/com/jigumulmi/admin/place/AdminPlaceService.java
@@ -12,6 +12,8 @@ import com.jigumulmi.admin.place.dto.response.AdminPlaceBusinessHourResponseDto.
 import com.jigumulmi.admin.place.dto.response.AdminPlaceListResponseDto.PlaceDto;
 import com.jigumulmi.admin.place.dto.response.AdminS3DeletePresignedUrlResponseDto;
 import com.jigumulmi.admin.place.dto.response.AdminS3PutPresignedUrlResponseDto;
+import com.jigumulmi.admin.place.manager.AdminPlaceManager;
+import com.jigumulmi.admin.place.manager.AdminPlaceValidator;
 import com.jigumulmi.common.PagedResponseDto;
 import com.jigumulmi.member.domain.Member;
 import com.jigumulmi.place.dto.ImageDto;
@@ -32,6 +34,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AdminPlaceService {
 
     private final AdminPlaceManager adminPlaceManager;
+    private final AdminPlaceValidator adminPlaceValidator;
 
     public PagedResponseDto<PlaceDto> getPlaceList(Pageable pageable,
         AdminGetPlaceListRequestDto requestDto) {
@@ -42,9 +45,7 @@ public class AdminPlaceService {
         return adminPlaceManager.getPlaceBasic(placeId);
     }
 
-    @Transactional
     public void updatePlaceBasic(Long placeId, AdminCreatePlaceRequestDto requestDto) {
-        adminPlaceManager.validatePlaceModification(placeId);
         adminPlaceManager.updatePlaceBasic(placeId, requestDto);
     }
 
@@ -52,9 +53,7 @@ public class AdminPlaceService {
         return adminPlaceManager.getPlaceImage(placeId);
     }
 
-    @Transactional
     public void updatePlaceImage(Long placeId, List<ImageDto> imageDtoList) {
-        adminPlaceManager.validatePlaceModification(placeId);
         adminPlaceManager.updatePlaceImage(placeId, imageDtoList);
     }
 
@@ -62,15 +61,11 @@ public class AdminPlaceService {
         return adminPlaceManager.getMenu(placeId);
     }
 
-    @Transactional
     public void updateMenu(Long placeId, List<MenuDto> menuDtoList) {
-        adminPlaceManager.validatePlaceModification(placeId);
         adminPlaceManager.updateMenu(placeId, menuDtoList);
     }
 
-    @Transactional
     public void updateFixedBusinessHour(Long placeId, WeeklyBusinessHourDto requestDto) {
-        adminPlaceManager.validatePlaceModification(placeId);
         adminPlaceManager.updateFixedBusinessHour(placeId, requestDto);
     }
 
@@ -110,7 +105,7 @@ public class AdminPlaceService {
     }
 
     public void deletePlace(Long placeId) {
-        adminPlaceManager.validatePlaceModification(placeId);
+        adminPlaceValidator.validatePlaceRemoval(placeId);
         adminPlaceManager.deletePlace(placeId);
         adminPlaceManager.deleteMenuImageFileList(placeId);
     }

--- a/src/main/java/com/jigumulmi/admin/place/AdminPlaceService.java
+++ b/src/main/java/com/jigumulmi/admin/place/AdminPlaceService.java
@@ -65,7 +65,9 @@ public class AdminPlaceService {
         return adminPlaceManager.getMenu(placeId);
     }
 
+    @Transactional
     public void updateMenu(Long placeId, List<MenuDto> menuDtoList) {
+        adminPlaceValidator.validateMenuUpdate(placeId, menuDtoList);
         adminPlaceManager.updateMenu(placeId, menuDtoList);
     }
 

--- a/src/main/java/com/jigumulmi/admin/place/AdminPlaceService.java
+++ b/src/main/java/com/jigumulmi/admin/place/AdminPlaceService.java
@@ -55,7 +55,9 @@ public class AdminPlaceService {
         return adminPlaceManager.getPlaceImage(placeId);
     }
 
+    @Transactional
     public void updatePlaceImage(Long placeId, List<ImageDto> imageDtoList) {
+        adminPlaceValidator.validatePlaceImageUpdate(placeId, imageDtoList);
         adminPlaceManager.updatePlaceImage(placeId, imageDtoList);
     }
 

--- a/src/main/java/com/jigumulmi/admin/place/AdminPlaceService.java
+++ b/src/main/java/com/jigumulmi/admin/place/AdminPlaceService.java
@@ -42,7 +42,9 @@ public class AdminPlaceService {
         return adminPlaceManager.getPlaceBasic(placeId);
     }
 
+    @Transactional
     public void updatePlaceBasic(Long placeId, AdminCreatePlaceRequestDto requestDto) {
+        adminPlaceManager.validatePlaceModification(placeId);
         adminPlaceManager.updatePlaceBasic(placeId, requestDto);
     }
 
@@ -50,7 +52,9 @@ public class AdminPlaceService {
         return adminPlaceManager.getPlaceImage(placeId);
     }
 
+    @Transactional
     public void updatePlaceImage(Long placeId, List<ImageDto> imageDtoList) {
+        adminPlaceManager.validatePlaceModification(placeId);
         adminPlaceManager.updatePlaceImage(placeId, imageDtoList);
     }
 
@@ -58,11 +62,15 @@ public class AdminPlaceService {
         return adminPlaceManager.getMenu(placeId);
     }
 
+    @Transactional
     public void updateMenu(Long placeId, List<MenuDto> menuDtoList) {
+        adminPlaceManager.validatePlaceModification(placeId);
         adminPlaceManager.updateMenu(placeId, menuDtoList);
     }
 
+    @Transactional
     public void updateFixedBusinessHour(Long placeId, WeeklyBusinessHourDto requestDto) {
+        adminPlaceManager.validatePlaceModification(placeId);
         adminPlaceManager.updateFixedBusinessHour(placeId, requestDto);
     }
 
@@ -102,6 +110,7 @@ public class AdminPlaceService {
     }
 
     public void deletePlace(Long placeId) {
+        adminPlaceManager.validatePlaceModification(placeId);
         adminPlaceManager.deletePlace(placeId);
         adminPlaceManager.deleteMenuImageFileList(placeId);
     }

--- a/src/main/java/com/jigumulmi/admin/place/AdminPlaceService.java
+++ b/src/main/java/com/jigumulmi/admin/place/AdminPlaceService.java
@@ -45,7 +45,9 @@ public class AdminPlaceService {
         return adminPlaceManager.getPlaceBasic(placeId);
     }
 
+    @Transactional
     public void updatePlaceBasic(Long placeId, AdminCreatePlaceRequestDto requestDto) {
+        adminPlaceValidator.validatePlaceBasicUpdate(placeId, requestDto);
         adminPlaceManager.updatePlaceBasic(placeId, requestDto);
     }
 

--- a/src/main/java/com/jigumulmi/admin/place/AdminPlaceService.java
+++ b/src/main/java/com/jigumulmi/admin/place/AdminPlaceService.java
@@ -100,7 +100,7 @@ public class AdminPlaceService {
 
     @Transactional
     public void togglePlaceApprove(Long placeId, boolean approve) {
-        adminPlaceManager.validatePlaceApprovalIfNeeded(placeId, approve);
+        adminPlaceValidator.validatePlaceApprovalIfNeeded(placeId, approve);
         adminPlaceManager.togglePlaceApprove(placeId, approve);
     }
 

--- a/src/main/java/com/jigumulmi/admin/place/dto/request/TogglePlaceApproveRequestDto.java
+++ b/src/main/java/com/jigumulmi/admin/place/dto/request/TogglePlaceApproveRequestDto.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class TogglePlaceApproveRequestDto {
 
-    @Schema(title = "승인 여부", requiredMode = RequiredMode.REQUIRED)
+    @Schema(description = "승인 요청 -> true, 미승인 요청 -> false", requiredMode = RequiredMode.REQUIRED)
     @NotNull
-    private Boolean isApproved;
+    private Boolean approve;
 }

--- a/src/main/java/com/jigumulmi/admin/place/manager/AdminPlaceManager.java
+++ b/src/main/java/com/jigumulmi/admin/place/manager/AdminPlaceManager.java
@@ -18,7 +18,6 @@ import com.jigumulmi.common.FileUtils;
 import com.jigumulmi.common.PagedResponseDto;
 import com.jigumulmi.common.WeekUtils;
 import com.jigumulmi.config.exception.CustomException;
-import com.jigumulmi.config.exception.errorCode.AdminErrorCode;
 import com.jigumulmi.config.exception.errorCode.CommonErrorCode;
 import com.jigumulmi.member.domain.Member;
 import com.jigumulmi.place.domain.FixedBusinessHour;
@@ -35,7 +34,6 @@ import com.jigumulmi.place.dto.MenuDto;
 import com.jigumulmi.place.dto.PositionDto;
 import com.jigumulmi.place.dto.response.DistrictResponseDto;
 import com.jigumulmi.place.dto.response.PlaceCategoryDto;
-import com.jigumulmi.place.dto.response.SubwayStationResponseDto;
 import com.jigumulmi.place.repository.FixedBusinessHourRepository;
 import com.jigumulmi.place.repository.MenuRepository;
 import com.jigumulmi.place.repository.PlaceCategoryMappingRepository;
@@ -329,54 +327,6 @@ public class AdminPlaceManager {
 
         placeRepository.save(place);
         return AdminCreatePlaceResponseDto.builder().placeId(place.getId()).build();
-    }
-
-    @Transactional(readOnly = true)
-    public void validatePlaceApprovalIfNeeded(Long placeId, boolean approve) {
-        if (!approve) {
-            return;
-        }
-
-        AdminPlaceBasicResponseDto placeBasic = getPlaceBasic(placeId);
-        if (placeBasic.getName().isBlank() || placeBasic.getAddress().isBlank()
-            || placeBasic.getRegion() == null || placeBasic.getDistrict() == null) {
-            throw new CustomException(AdminErrorCode.INVALID_PLACE_APPROVAL, "기본 정보 누락");
-        }
-
-        PositionDto position = placeBasic.getPosition();
-        if (position.getLatitude() == null || (position.getLatitude() < 33
-            || position.getLatitude() > 39)
-            || position.getLongitude() == null || (position.getLongitude() < 124
-            || position.getLongitude() > 132)) {
-            throw new CustomException(AdminErrorCode.INVALID_PLACE_APPROVAL, "좌표 오류");
-        }
-
-        List<SubwayStationResponseDto> subwayStationList = placeBasic.getSubwayStationList();
-        if (subwayStationList == null || subwayStationList.isEmpty()) {
-            throw new CustomException(AdminErrorCode.INVALID_PLACE_APPROVAL, "지하철 누락");
-        }
-
-        List<PlaceCategoryDto> categoryList = placeBasic.getCategoryList();
-        if (categoryList == null || categoryList.isEmpty()) {
-            throw new CustomException(AdminErrorCode.INVALID_PLACE_APPROVAL, "카테고리 누락");
-        }
-
-        List<ImageDto> placeImage = getPlaceImage(placeId);
-        if (placeImage.isEmpty()) {
-            throw new CustomException(AdminErrorCode.INVALID_PLACE_APPROVAL, "이미지 누락");
-        }
-
-        List<MenuDto> menuDtoList = getMenu(placeId);
-        if (menuDtoList.isEmpty()) {
-            throw new CustomException(AdminErrorCode.INVALID_PLACE_APPROVAL, "메뉴 누락");
-        }
-
-        WeeklyBusinessHourDto fixedBusinessHour = getFixedBusinessHour(placeId);
-        for (DayOfWeek dayOfWeek : DayOfWeek.values()) {
-            if (fixedBusinessHour.getBusinessHour(dayOfWeek) == null) {
-                throw new CustomException(AdminErrorCode.INVALID_PLACE_APPROVAL, "영업 시간 누락");
-            }
-        }
     }
 
     @Transactional

--- a/src/main/java/com/jigumulmi/admin/place/manager/AdminPlaceManager.java
+++ b/src/main/java/com/jigumulmi/admin/place/manager/AdminPlaceManager.java
@@ -1,5 +1,6 @@
-package com.jigumulmi.admin.place;
+package com.jigumulmi.admin.place.manager;
 
+import com.jigumulmi.admin.place.AdminCustomPlaceRepository;
 import com.jigumulmi.admin.place.dto.WeeklyBusinessHourDto;
 import com.jigumulmi.admin.place.dto.request.AdminCreatePlaceRequestDto;
 import com.jigumulmi.admin.place.dto.request.AdminCreateTemporaryBusinessHourRequestDto;
@@ -425,14 +426,5 @@ public class AdminPlaceManager {
         return AdminS3DeletePresignedUrlResponseDto.builder()
             .url(url)
             .build();
-    }
-
-    public void validatePlaceModification(Long placeId) {
-        Place place = placeRepository.findById(placeId)
-            .orElseThrow(() -> new CustomException(CommonErrorCode.RESOURCE_NOT_FOUND));
-
-        if (place.getIsApproved()) {
-            throw new CustomException(AdminErrorCode.INVALID_PLACE_MODIFICATION);
-        }
     }
 }

--- a/src/main/java/com/jigumulmi/admin/place/manager/AdminPlaceValidator.java
+++ b/src/main/java/com/jigumulmi/admin/place/manager/AdminPlaceValidator.java
@@ -1,6 +1,7 @@
 package com.jigumulmi.admin.place.manager;
 
 import com.jigumulmi.admin.place.dto.WeeklyBusinessHourDto;
+import com.jigumulmi.admin.place.dto.request.AdminCreatePlaceRequestDto;
 import com.jigumulmi.admin.place.dto.response.AdminPlaceBasicResponseDto;
 import com.jigumulmi.config.exception.CustomException;
 import com.jigumulmi.config.exception.errorCode.AdminErrorCode;
@@ -9,9 +10,12 @@ import com.jigumulmi.place.domain.Place;
 import com.jigumulmi.place.dto.ImageDto;
 import com.jigumulmi.place.dto.MenuDto;
 import com.jigumulmi.place.dto.PositionDto;
+import com.jigumulmi.place.dto.response.DistrictResponseDto;
 import com.jigumulmi.place.dto.response.PlaceCategoryDto;
 import com.jigumulmi.place.dto.response.SubwayStationResponseDto;
 import com.jigumulmi.place.repository.PlaceRepository;
+import com.jigumulmi.place.vo.District;
+import com.jigumulmi.place.vo.Region;
 import java.time.DayOfWeek;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -42,18 +46,12 @@ public class AdminPlaceValidator {
         }
 
         AdminPlaceBasicResponseDto placeBasic = adminPlaceManager.getPlaceBasic(placeId);
-        if (placeBasic.getName().isBlank() || placeBasic.getAddress().isBlank()
-            || placeBasic.getRegion() == null || placeBasic.getDistrict() == null) {
-            throw new CustomException(AdminErrorCode.INVALID_PLACE_APPROVAL, "기본 정보 누락");
-        }
+        validatePlaceEssential(placeBasic.getName(), placeBasic.getAddress(),
+            placeBasic.getRegion(),
+            DistrictResponseDto.toDistrict(placeBasic.getDistrict()));
 
         PositionDto position = placeBasic.getPosition();
-        if (position.getLatitude() == null || (position.getLatitude() < 33
-            || position.getLatitude() > 39)
-            || position.getLongitude() == null || (position.getLongitude() < 124
-            || position.getLongitude() > 132)) {
-            throw new CustomException(AdminErrorCode.INVALID_PLACE_APPROVAL, "좌표 오류");
-        }
+        validatePlacePosition(position);
 
         List<SubwayStationResponseDto> subwayStationList = placeBasic.getSubwayStationList();
         if (subwayStationList == null || subwayStationList.isEmpty()) {
@@ -61,9 +59,7 @@ public class AdminPlaceValidator {
         }
 
         List<PlaceCategoryDto> categoryList = placeBasic.getCategoryList();
-        if (categoryList == null || categoryList.isEmpty()) {
-            throw new CustomException(AdminErrorCode.INVALID_PLACE_APPROVAL, "카테고리 누락");
-        }
+        validateCategory(categoryList);
 
         List<ImageDto> placeImage = adminPlaceManager.getPlaceImage(placeId);
         if (placeImage.isEmpty()) {
@@ -71,9 +67,7 @@ public class AdminPlaceValidator {
         }
 
         List<MenuDto> menuDtoList = adminPlaceManager.getMenu(placeId);
-        if (menuDtoList.isEmpty()) {
-            throw new CustomException(AdminErrorCode.INVALID_PLACE_APPROVAL, "메뉴 누락");
-        }
+        validateMenu(menuDtoList);
 
         WeeklyBusinessHourDto fixedBusinessHour = adminPlaceManager.getFixedBusinessHour(placeId);
         for (DayOfWeek dayOfWeek : DayOfWeek.values()) {
@@ -83,5 +77,55 @@ public class AdminPlaceValidator {
         }
     }
 
+    private void validateMenu(List<MenuDto> menuList) {
+        if (menuList == null || menuList.isEmpty() || menuList.stream()
+            .allMatch(menu -> menu.getName().isBlank())) {
+            throw new CustomException(AdminErrorCode.INVALID_PLACE_APPROVAL, "메뉴 누락");
+        }
+    }
+
+    private void validateCategory(List<PlaceCategoryDto> categoryList) {
+        if (categoryList == null || categoryList.isEmpty() || categoryList.stream()
+            .allMatch(dto -> dto.getCategoryGroup() == null)) {
+            throw new CustomException(AdminErrorCode.INVALID_PLACE_APPROVAL, "카테고리 누락");
+        }
+    }
+
+    private void validatePlacePosition(PositionDto position) {
+        if (position.getLatitude() == null || (position.getLatitude() < 33
+            || position.getLatitude() > 39)
+            || position.getLongitude() == null || (position.getLongitude() < 124
+            || position.getLongitude() > 132)) {
+            throw new CustomException(AdminErrorCode.INVALID_PLACE_APPROVAL, "좌표 오류");
+        }
+    }
+
+    private void validatePlaceEssential(String name, String address, Region region,
+        District district) {
+        if (name.isBlank() || address.isBlank() || region == null || district == null) {
+            throw new CustomException(AdminErrorCode.INVALID_PLACE_APPROVAL, "기본 정보 누락");
+        }
+    }
+
+    public void validatePlaceBasicUpdate(Long placeId, AdminCreatePlaceRequestDto requestDto) {
+        Place place = placeRepository.findById(placeId)
+            .orElseThrow(() -> new CustomException(CommonErrorCode.RESOURCE_NOT_FOUND));
+
+        if (!place.getIsApproved()) {
+            return;
+        }
+
+        validatePlaceEssential(requestDto.getName(), requestDto.getAddress(),
+            requestDto.getRegion(), requestDto.getDistrict());
+
+        if (requestDto.getSubwayStationIdList() == null || requestDto.getSubwayStationIdList()
+            .isEmpty()) {
+            throw new CustomException(AdminErrorCode.INVALID_PLACE_APPROVAL, "지하철 누락");
+        }
+
+        validatePlacePosition(requestDto.getPosition());
+
+        validateCategory(requestDto.getCategoryList());
+    }
 
 }

--- a/src/main/java/com/jigumulmi/admin/place/manager/AdminPlaceValidator.java
+++ b/src/main/java/com/jigumulmi/admin/place/manager/AdminPlaceValidator.java
@@ -141,4 +141,15 @@ public class AdminPlaceValidator {
         }
     }
 
+    public void validateMenuUpdate(Long placeId, List<MenuDto> menuDtoList) {
+        Place place = placeRepository.findById(placeId)
+            .orElseThrow(() -> new CustomException(CommonErrorCode.RESOURCE_NOT_FOUND));
+
+        if (!place.getIsApproved()) {
+            return;
+        }
+
+        validateMenu(menuDtoList);
+    }
+
 }

--- a/src/main/java/com/jigumulmi/admin/place/manager/AdminPlaceValidator.java
+++ b/src/main/java/com/jigumulmi/admin/place/manager/AdminPlaceValidator.java
@@ -46,12 +46,12 @@ public class AdminPlaceValidator {
         }
 
         AdminPlaceBasicResponseDto placeBasic = adminPlaceManager.getPlaceBasic(placeId);
-        validatePlaceEssential(placeBasic.getName(), placeBasic.getAddress(),
+        checkPlaceEssential(placeBasic.getName(), placeBasic.getAddress(),
             placeBasic.getRegion(),
             DistrictResponseDto.toDistrict(placeBasic.getDistrict()));
 
         PositionDto position = placeBasic.getPosition();
-        validatePlacePosition(position);
+        checkPlacePosition(position);
 
         List<SubwayStationResponseDto> subwayStationList = placeBasic.getSubwayStationList();
         if (subwayStationList == null || subwayStationList.isEmpty()) {
@@ -59,7 +59,7 @@ public class AdminPlaceValidator {
         }
 
         List<PlaceCategoryDto> categoryList = placeBasic.getCategoryList();
-        validateCategory(categoryList);
+        checkCategory(categoryList);
 
         List<ImageDto> placeImage = adminPlaceManager.getPlaceImage(placeId);
         if (placeImage.isEmpty()) {
@@ -67,7 +67,7 @@ public class AdminPlaceValidator {
         }
 
         List<MenuDto> menuDtoList = adminPlaceManager.getMenu(placeId);
-        validateMenu(menuDtoList);
+        checkMenu(menuDtoList);
 
         WeeklyBusinessHourDto fixedBusinessHour = adminPlaceManager.getFixedBusinessHour(placeId);
         for (DayOfWeek dayOfWeek : DayOfWeek.values()) {
@@ -77,21 +77,21 @@ public class AdminPlaceValidator {
         }
     }
 
-    private void validateMenu(List<MenuDto> menuList) {
+    private void checkMenu(List<MenuDto> menuList) {
         if (menuList == null || menuList.isEmpty() || menuList.stream()
             .allMatch(menu -> menu.getName().isBlank())) {
             throw new CustomException(AdminErrorCode.INVALID_PLACE_APPROVAL, "메뉴 누락");
         }
     }
 
-    private void validateCategory(List<PlaceCategoryDto> categoryList) {
+    private void checkCategory(List<PlaceCategoryDto> categoryList) {
         if (categoryList == null || categoryList.isEmpty() || categoryList.stream()
             .allMatch(dto -> dto.getCategoryGroup() == null)) {
             throw new CustomException(AdminErrorCode.INVALID_PLACE_APPROVAL, "카테고리 누락");
         }
     }
 
-    private void validatePlacePosition(PositionDto position) {
+    private void checkPlacePosition(PositionDto position) {
         if (position.getLatitude() == null || (position.getLatitude() < 33
             || position.getLatitude() > 39)
             || position.getLongitude() == null || (position.getLongitude() < 124
@@ -100,7 +100,7 @@ public class AdminPlaceValidator {
         }
     }
 
-    private void validatePlaceEssential(String name, String address, Region region,
+    private void checkPlaceEssential(String name, String address, Region region,
         District district) {
         if (name.isBlank() || address.isBlank() || region == null || district == null) {
             throw new CustomException(AdminErrorCode.INVALID_PLACE_APPROVAL, "기본 정보 누락");
@@ -115,7 +115,7 @@ public class AdminPlaceValidator {
             return;
         }
 
-        validatePlaceEssential(requestDto.getName(), requestDto.getAddress(),
+        checkPlaceEssential(requestDto.getName(), requestDto.getAddress(),
             requestDto.getRegion(), requestDto.getDistrict());
 
         if (requestDto.getSubwayStationIdList() == null || requestDto.getSubwayStationIdList()
@@ -123,9 +123,9 @@ public class AdminPlaceValidator {
             throw new CustomException(AdminErrorCode.INVALID_PLACE_APPROVAL, "지하철 누락");
         }
 
-        validatePlacePosition(requestDto.getPosition());
+        checkPlacePosition(requestDto.getPosition());
 
-        validateCategory(requestDto.getCategoryList());
+        checkCategory(requestDto.getCategoryList());
     }
 
     public void validatePlaceImageUpdate(Long placeId, List<ImageDto> imageDtoList) {
@@ -149,7 +149,7 @@ public class AdminPlaceValidator {
             return;
         }
 
-        validateMenu(menuDtoList);
+        checkMenu(menuDtoList);
     }
 
 }

--- a/src/main/java/com/jigumulmi/admin/place/manager/AdminPlaceValidator.java
+++ b/src/main/java/com/jigumulmi/admin/place/manager/AdminPlaceValidator.java
@@ -1,16 +1,28 @@
 package com.jigumulmi.admin.place.manager;
 
+import com.jigumulmi.admin.place.dto.WeeklyBusinessHourDto;
+import com.jigumulmi.admin.place.dto.response.AdminPlaceBasicResponseDto;
 import com.jigumulmi.config.exception.CustomException;
 import com.jigumulmi.config.exception.errorCode.AdminErrorCode;
 import com.jigumulmi.config.exception.errorCode.CommonErrorCode;
 import com.jigumulmi.place.domain.Place;
+import com.jigumulmi.place.dto.ImageDto;
+import com.jigumulmi.place.dto.MenuDto;
+import com.jigumulmi.place.dto.PositionDto;
+import com.jigumulmi.place.dto.response.PlaceCategoryDto;
+import com.jigumulmi.place.dto.response.SubwayStationResponseDto;
 import com.jigumulmi.place.repository.PlaceRepository;
+import java.time.DayOfWeek;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
 public class AdminPlaceValidator {
+
+    private final AdminPlaceManager adminPlaceManager;
 
     private final PlaceRepository placeRepository;
 
@@ -22,5 +34,54 @@ public class AdminPlaceValidator {
             throw new CustomException(AdminErrorCode.INVALID_PLACE_REMOVAL);
         }
     }
+
+    @Transactional(readOnly = true)
+    public void validatePlaceApprovalIfNeeded(Long placeId, boolean approve) {
+        if (!approve) {
+            return;
+        }
+
+        AdminPlaceBasicResponseDto placeBasic = adminPlaceManager.getPlaceBasic(placeId);
+        if (placeBasic.getName().isBlank() || placeBasic.getAddress().isBlank()
+            || placeBasic.getRegion() == null || placeBasic.getDistrict() == null) {
+            throw new CustomException(AdminErrorCode.INVALID_PLACE_APPROVAL, "기본 정보 누락");
+        }
+
+        PositionDto position = placeBasic.getPosition();
+        if (position.getLatitude() == null || (position.getLatitude() < 33
+            || position.getLatitude() > 39)
+            || position.getLongitude() == null || (position.getLongitude() < 124
+            || position.getLongitude() > 132)) {
+            throw new CustomException(AdminErrorCode.INVALID_PLACE_APPROVAL, "좌표 오류");
+        }
+
+        List<SubwayStationResponseDto> subwayStationList = placeBasic.getSubwayStationList();
+        if (subwayStationList == null || subwayStationList.isEmpty()) {
+            throw new CustomException(AdminErrorCode.INVALID_PLACE_APPROVAL, "지하철 누락");
+        }
+
+        List<PlaceCategoryDto> categoryList = placeBasic.getCategoryList();
+        if (categoryList == null || categoryList.isEmpty()) {
+            throw new CustomException(AdminErrorCode.INVALID_PLACE_APPROVAL, "카테고리 누락");
+        }
+
+        List<ImageDto> placeImage = adminPlaceManager.getPlaceImage(placeId);
+        if (placeImage.isEmpty()) {
+            throw new CustomException(AdminErrorCode.INVALID_PLACE_APPROVAL, "이미지 누락");
+        }
+
+        List<MenuDto> menuDtoList = adminPlaceManager.getMenu(placeId);
+        if (menuDtoList.isEmpty()) {
+            throw new CustomException(AdminErrorCode.INVALID_PLACE_APPROVAL, "메뉴 누락");
+        }
+
+        WeeklyBusinessHourDto fixedBusinessHour = adminPlaceManager.getFixedBusinessHour(placeId);
+        for (DayOfWeek dayOfWeek : DayOfWeek.values()) {
+            if (fixedBusinessHour.getBusinessHour(dayOfWeek) == null) {
+                throw new CustomException(AdminErrorCode.INVALID_PLACE_APPROVAL, "영업 시간 누락");
+            }
+        }
+    }
+
 
 }

--- a/src/main/java/com/jigumulmi/admin/place/manager/AdminPlaceValidator.java
+++ b/src/main/java/com/jigumulmi/admin/place/manager/AdminPlaceValidator.java
@@ -47,8 +47,7 @@ public class AdminPlaceValidator {
 
         AdminPlaceBasicResponseDto placeBasic = adminPlaceManager.getPlaceBasic(placeId);
         checkPlaceEssential(placeBasic.getName(), placeBasic.getAddress(),
-            placeBasic.getRegion(),
-            DistrictResponseDto.toDistrict(placeBasic.getDistrict()));
+            placeBasic.getRegion(), DistrictResponseDto.toDistrict(placeBasic.getDistrict()));
 
         PositionDto position = placeBasic.getPosition();
         checkPlacePosition(position);

--- a/src/main/java/com/jigumulmi/admin/place/manager/AdminPlaceValidator.java
+++ b/src/main/java/com/jigumulmi/admin/place/manager/AdminPlaceValidator.java
@@ -1,0 +1,26 @@
+package com.jigumulmi.admin.place.manager;
+
+import com.jigumulmi.config.exception.CustomException;
+import com.jigumulmi.config.exception.errorCode.AdminErrorCode;
+import com.jigumulmi.config.exception.errorCode.CommonErrorCode;
+import com.jigumulmi.place.domain.Place;
+import com.jigumulmi.place.repository.PlaceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AdminPlaceValidator {
+
+    private final PlaceRepository placeRepository;
+
+    public void validatePlaceRemoval(Long placeId) {
+        Place place = placeRepository.findById(placeId)
+            .orElseThrow(() -> new CustomException(CommonErrorCode.RESOURCE_NOT_FOUND));
+
+        if (place.getIsApproved()) {
+            throw new CustomException(AdminErrorCode.INVALID_PLACE_REMOVAL);
+        }
+    }
+
+}

--- a/src/main/java/com/jigumulmi/admin/place/manager/AdminPlaceValidator.java
+++ b/src/main/java/com/jigumulmi/admin/place/manager/AdminPlaceValidator.java
@@ -128,4 +128,17 @@ public class AdminPlaceValidator {
         validateCategory(requestDto.getCategoryList());
     }
 
+    public void validatePlaceImageUpdate(Long placeId, List<ImageDto> imageDtoList) {
+        Place place = placeRepository.findById(placeId)
+            .orElseThrow(() -> new CustomException(CommonErrorCode.RESOURCE_NOT_FOUND));
+
+        if (!place.getIsApproved()) {
+            return;
+        }
+
+        if (imageDtoList == null || imageDtoList.isEmpty()) {
+            throw new CustomException(AdminErrorCode.INVALID_PLACE_APPROVAL, "이미지 누락");
+        }
+    }
+
 }

--- a/src/main/java/com/jigumulmi/config/exception/errorCode/AdminErrorCode.java
+++ b/src/main/java/com/jigumulmi/config/exception/errorCode/AdminErrorCode.java
@@ -11,7 +11,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 @Getter
 public enum AdminErrorCode implements ErrorCode {
-    INVALID_PLACE_APPROVAL(HttpStatus.BAD_REQUEST, "Check place data")
+    INVALID_PLACE_APPROVAL(HttpStatus.BAD_REQUEST, "Check place data"),
+    INVALID_PLACE_MODIFICATION(HttpStatus.BAD_REQUEST, "Check place approval")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/jigumulmi/config/exception/errorCode/AdminErrorCode.java
+++ b/src/main/java/com/jigumulmi/config/exception/errorCode/AdminErrorCode.java
@@ -12,7 +12,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum AdminErrorCode implements ErrorCode {
     INVALID_PLACE_APPROVAL(HttpStatus.BAD_REQUEST, "Check place data"),
-    INVALID_PLACE_REMOVAL(HttpStatus.BAD_REQUEST, "Check place approval")
+    INVALID_PLACE_REMOVAL(HttpStatus.BAD_REQUEST, "Check place approval"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/jigumulmi/config/exception/errorCode/AdminErrorCode.java
+++ b/src/main/java/com/jigumulmi/config/exception/errorCode/AdminErrorCode.java
@@ -12,7 +12,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum AdminErrorCode implements ErrorCode {
     INVALID_PLACE_APPROVAL(HttpStatus.BAD_REQUEST, "Check place data"),
-    INVALID_PLACE_MODIFICATION(HttpStatus.BAD_REQUEST, "Check place approval")
+    INVALID_PLACE_REMOVAL(HttpStatus.BAD_REQUEST, "Check place approval")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/jigumulmi/place/domain/Place.java
+++ b/src/main/java/com/jigumulmi/place/domain/Place.java
@@ -210,7 +210,7 @@ public class Place extends Timestamped {
         this.kakaoPlaceId = requestDto.getKakaoPlaceId();
     }
 
-    public void adminUpdateIsApproved(Boolean isApproved) {
-        this.isApproved = isApproved;
+    public void adminUpdateIsApproved(boolean approve) {
+        this.isApproved = approve;
     }
 }

--- a/src/main/java/com/jigumulmi/place/dto/response/DistrictResponseDto.java
+++ b/src/main/java/com/jigumulmi/place/dto/response/DistrictResponseDto.java
@@ -22,4 +22,8 @@ public class DistrictResponseDto {
             .build();
     }
 
+    public static District toDistrict(DistrictResponseDto dto) {
+        return District.ofId(dto.getId());
+    }
+
 }


### PR DESCRIPTION
<!-- 
PR 제목에 쓰는 prefix는 다음과 같습니다.
Feat : 새로운 기능에 대한 작업
BugFix : 버그 수정에 대한 작업
Refactor : 코드 리팩토링에 대한 작업
Build : 빌드 관련 파일 수정에 대한 작업
Style : 코드 스타일 혹은 포맷 등에 관한 작업
CI : CI 관련 설정 수정에 대한 작업
Docs : 문서 수정에 대한 작업
Test : 테스트 코드 관련 작업
Chore : 그 외 자잘한 수정에 대한 작업(파일 이름 변경, 주석 수정 등)
-->

## 작업사항
<!-- 무엇을 왜 했는지 -->
- 검증 로직을 담당하는 매니저 계층인 AdminPlaceValidator 생성
- 장소 삭제 시에는 승인 해제를 먼저 해야 가능
- 장소 수정 시에도 삭제 처럼 승인 해제를 강제하면 다시 승인해줘야 하는 불편함 때문에, 서비스 로직에 검증 절차 추가
- 장소 승인 검증 로직에서 메뉴와 카테고리 세부 검증 추가
- 장소 승인 API 성공 응답 코드 204로 수정
  - 응답 데이터 없는 경우 204 통일
- 승인 API 파라미터명 `approve`로 수정

## 참고사항
- 고정 영업시간 수정 검증은 컨트롤러에서 완벽하게 처리되기 때문에 그 이후에 다시 하지 않음

## 관련 이슈
- closed #